### PR TITLE
Allow the server.log path to be passed as a command line agrument

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -1,12 +1,16 @@
 #!/usr/bin/env python
-import re, datetime, operator
+import re, datetime, operator, sys
 
 actions = {
 	"login": re.compile("([0-9]{4})\-([0-9]{2})\-([0-9]{2}) ([0-2][0-9])\:([0-9]{2})\:([0-9]{2}) \[INFO\] ([A-z0-9]*) ?\[\/[0-9.]{4,15}\:[0-9]*\]"),
 	"logout": re.compile("([0-9]{4})\-([0-9]{2})\-([0-9]{2}) ([0-2][0-9])\:([0-9]{2})\:([0-9]{2}) \[INFO\] ([A-z0-9]*) lost connection")
 }
 
-f = open("server.log")
+path = "server.log"
+if sys.argv[1]:
+    path = sys.argv[1]
+
+f = open(path)
 
 online = {}
 totals = {}


### PR DESCRIPTION
The default functionality will remain the same if the path is not passed on the command line.
