### PR TITLE
continue instead of break to avoid premature stoppage

### DIFF
--- a/bin/mclp
+++ b/bin/mclp
@@ -46,7 +46,7 @@ for line in f.readlines():
             if player in online:
                 delta = time - online[player]
             else:
-                break
+                continue
 
             totals[player] += delta.seconds
             del online[player]


### PR DESCRIPTION
The break there stops the loop if a player logs out without being first logged in. Replacing with a continue allows the file to continue processing.
